### PR TITLE
Fix crash issue of UITextField contextMenu action

### DIFF
--- a/Sources/StreamChatUI/Controller/NameGroupViewController.swift
+++ b/Sources/StreamChatUI/Controller/NameGroupViewController.swift
@@ -229,10 +229,6 @@ extension NameGroupViewController: UITableViewDataSource {
 class ViewWithRadius: UIView {}
 // MARK: - UITextField extension
 extension UITextField {
-    open override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        return true
-    }
-    
     public func setAttributedPlaceHolder(placeHolder: String) {
         let attributeString = [
             NSAttributedString.Key.foregroundColor: Appearance.default.colorPalette.searchPlaceHolder,


### PR DESCRIPTION
### 🔗 Issue Link

No.25 : https://docs.google.com/document/d/1_eydsvMZkf0yUV5kaDwBSZIpsMkSmZkbMW-SYFhMYo8/edit

### 🎯 Goal

To fix crash

### 🛠 Implementation

Remove override func of UITextField
