### PR TITLE
Chat  Message Reply & Copy Action Fixes

### DIFF
--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -717,7 +717,13 @@ open class ComposerVC: _ViewController,
     }
     
     @objc open func clearContent(sender: UIButton) {
-        content.clear()
+        if content.state == .quote {
+            var newContent = Content.initial()
+            newContent.text = composerView.inputMessageView.textView.text
+            content = newContent
+        } else {
+            content.clear()
+        }
     }
 
     open func showPayment() {

--- a/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
+++ b/Sources/StreamChatUI/MessageActionsPopup/ChatMessageActionsVC.swift
@@ -199,9 +199,12 @@ open class ChatMessageActionsVC: _ViewController, ThemeProvider {
         CopyActionItem(
             action: { [weak self] _ in
                 guard let self = self else { return }
+                Snackbar.hide()
                 UIPasteboard.general.string = self.message?.text
-                Snackbar.show(text: "", messageType: StreamChatMessageType.MessageCopied)
-                self.delegate?.chatMessageActionsVCDidFinish(self)
+                DispatchQueue.main.async {
+                    Snackbar.show(text: "", messageType: StreamChatMessageType.MessageCopied)
+                    self.delegate?.chatMessageActionsVCDidFinish(self)
+                }
             },
             appearance: appearance
         )


### PR DESCRIPTION
### 🔗 Issue Link

https://docs.google.com/document/d/1Azm9RIAvnW4-KlRcF-aeRGn56W3Mx24H8sAi_kty2eU/edit

### 🎯  Fixed Bug

11 - Textbox become blank after close “Reply to Message"
13 - Copied snackbar should be displayed everytime user copies message
