### PR TITLE
Request Payment Wrong Card Issue and Theme wise Card shown on success

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/WalletRequestPayBubble.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/WalletRequestPayBubble.swift
@@ -252,9 +252,7 @@ class WalletRequestPayBubble: UITableViewCell {
             userInfo["recipientUserId"] = payload.extraData?.recipientUserId
             userInfo["requestedImageUrl"] = payload.extraData?.requestedImageUrl
             userInfo["paymentTheme"] = payload.extraData?.sentOnePaymentTheme
-            if let channelId = channelId {
-                userInfo["channelId"] = channelId.description
-            }
+            userInfo["channelId"] = channelId
             NotificationCenter.default.post(name: .payRequestTapAction, object: nil, userInfo: userInfo)
         }
     }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/WalletRequestPayBubble.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/WalletRequestPayBubble.swift
@@ -27,7 +27,7 @@ class WalletRequestPayBubble: UITableViewCell {
     var content: ChatMessage?
     public lazy var dateFormatter: DateFormatter = .makeDefault()
     var isSender = false
-    var channel: ChatChannel?
+    var channelId: ChannelId?
     var chatClient: ChatClient?
     var client: ChatClient?
     var walletPaymentType: WalletAttachmentPayload.PaymentType = .pay
@@ -360,12 +360,11 @@ class WalletRequestPayBubble: UITableViewCell {
             userInfo["recipientName"] = requestedUserName(raw: payload.extraData)
             userInfo["recipientUserId"] = requestedUserId(raw: payload.extraData)
             userInfo["requestedImageUrl"] = requestedImageUrl(raw: payload.extraData)
+            userInfo["paymentTheme"] = requestedThemeURL(raw: payload.extraData)
+            if let channelId = channelId {
+                userInfo["channelId"] = channelId.description
+            }
             NotificationCenter.default.post(name: .payRequestTapAction, object: nil, userInfo: userInfo)
-        } else {
-            guard let channelId = channel?.cid else { return }
-            var userInfo = [String: Any]()
-            userInfo["channelId"] = channelId
-            NotificationCenter.default.post(name: .sendGiftPacketTapAction, object: nil, userInfo: userInfo)
         }
     }
 }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/WalletRequestPayBubble.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/WalletRequestPayBubble.swift
@@ -251,7 +251,7 @@ class WalletRequestPayBubble: UITableViewCell {
             userInfo["recipientName"] = payload.extraData?.recipientName
             userInfo["recipientUserId"] = payload.extraData?.recipientUserId
             userInfo["requestedImageUrl"] = payload.extraData?.requestedImageUrl
-            userInfo["paymentTheme"] = payload.extraData?.pay
+            userInfo["paymentTheme"] = payload.extraData?.sentOnePaymentTheme
             if let channelId = channelId {
                 userInfo["channelId"] = channelId.description
             }

--- a/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessageListVC.swift
@@ -437,6 +437,9 @@ open class ChatMessageListVC:
                         for: indexPath) as? WalletRequestPayBubble else {
                             return UITableViewCell()
                         }
+                    if let channel = dataSource?.channel(for: self) {
+                        cell.channelId = channel.cid
+                    }
                     cell.isSender = isMessageFromCurrentUser
                     cell.client = client
                     cell.layoutOptions = cellLayoutOptionsForMessage(at: indexPath)
@@ -450,6 +453,9 @@ open class ChatMessageListVC:
                     for: indexPath) as? TableViewCellWallePayBubbleIncoming else {
                         return UITableViewCell()
                     }
+                if let channel = dataSource?.channel(for: self) {
+                    cell.channelId = channel.cid
+                }
                 cell.client = client
                 cell.layoutOptions = cellLayoutOptionsForMessage(at: indexPath)
                 cell.content = message

--- a/Sources/StreamChatUI/ChatMessageList/CryptoReceiveBubble.swift
+++ b/Sources/StreamChatUI/ChatMessageList/CryptoReceiveBubble.swift
@@ -56,7 +56,7 @@ class CryptoReceiveBubble: UITableViewCell {
 
         sentThumbImageView = UIImageView()
         sentThumbImageView.backgroundColor = Appearance.default.colorPalette.background6
-        sentThumbImageView.image = Appearance.default.images.cryptoSentThumb
+        sentThumbImageView.image = nil
         sentThumbImageView.transform = .mirrorY
         sentThumbImageView.contentMode = .scaleAspectFill
         sentThumbImageView.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/StreamChatUI/ChatMessageList/CryptoSentBubble.swift
+++ b/Sources/StreamChatUI/ChatMessageList/CryptoSentBubble.swift
@@ -56,7 +56,7 @@ class CryptoSentBubble: UITableViewCell {
 
         sentThumbImageView = UIImageView()
         sentThumbImageView.backgroundColor = Appearance.default.colorPalette.background6
-        sentThumbImageView.image = Appearance.default.images.cryptoSentThumb
+        sentThumbImageView.image = nil
         sentThumbImageView.contentMode = .scaleAspectFill
         sentThumbImageView.translatesAutoresizingMaskIntoConstraints = false
         sentThumbImageView.clipsToBounds = true

--- a/Sources/StreamChatUI/Model/SendOneWallet.swift
+++ b/Sources/StreamChatUI/Model/SendOneWallet.swift
@@ -27,7 +27,7 @@ public struct SendOneWallet {
     public init() {
     }
 
-    public func toDictionary() -> [String: RawJSON] {
+   public func toDictionary() -> [String: RawJSON] {
         var dictOut = [String: RawJSON]()
         dictOut["myName"] = .string(myName ?? "")
         dictOut["myWalletAddress"] = .string(myWalletAddress ?? "")

--- a/Sources/StreamChatUI/Model/SendOneWallet.swift
+++ b/Sources/StreamChatUI/Model/SendOneWallet.swift
@@ -20,14 +20,14 @@ public struct SendOneWallet {
     public var txId: String?
     public var strFormattedAmount: String?
     public var paymentTheme: String?
-    public var channelId: ChannelId?
+    public var channelId: String?
     //number of fraction digits in transferAmount
     public var fractionDigits: Int = 0
 
     public init() {
     }
 
-   public func toDictionary() -> [String: RawJSON] {
+    public func toDictionary() -> [String: RawJSON] {
         var dictOut = [String: RawJSON]()
         dictOut["myName"] = .string(myName ?? "")
         dictOut["myWalletAddress"] = .string(myWalletAddress ?? "")
@@ -38,6 +38,7 @@ public struct SendOneWallet {
         dictOut["transferAmount"] = .number(Double(transferAmount ?? 0).rounded(toPlaces: 2))
         dictOut["txId"] = .string(txId ?? "")
         dictOut["paymentTheme"] = .string(paymentTheme ?? "")
+        dictOut["channelId"] = .string(channelId ?? "")
         return dictOut
     }
 }

--- a/Sources/StreamChatUI/Model/SendOneWallet.swift
+++ b/Sources/StreamChatUI/Model/SendOneWallet.swift
@@ -20,7 +20,7 @@ public struct SendOneWallet {
     public var txId: String?
     public var strFormattedAmount: String?
     public var paymentTheme: String?
-    public var channelId: String?
+    public var channelId: ChannelId?
     //number of fraction digits in transferAmount
     public var fractionDigits: Int = 0
 
@@ -38,7 +38,9 @@ public struct SendOneWallet {
         dictOut["transferAmount"] = .number(Double(transferAmount ?? 0).rounded(toPlaces: 2))
         dictOut["txId"] = .string(txId ?? "")
         dictOut["paymentTheme"] = .string(paymentTheme ?? "")
-        dictOut["channelId"] = .string(channelId ?? "")
+        if let channelId = channelId {
+            dictOut["channelId"] = .string(channelId.description)
+        }
         return dictOut
     }
 }

--- a/Sources/StreamChatUI/xibs/cells/TableViewCellWallePayBubbleIncoming.swift
+++ b/Sources/StreamChatUI/xibs/cells/TableViewCellWallePayBubbleIncoming.swift
@@ -289,9 +289,7 @@ public class TableViewCellWallePayBubbleIncoming: UITableViewCell {
             userInfo["recipientUserId"] = requestedUserId(raw: payload.extraData)
             userInfo["requestedImageUrl"] = requestedImageUrl(raw: payload.extraData)
             userInfo["paymentTheme"] = requestedThemeURL(raw: payload.extraData)
-            if let channelId = channelId {
-                userInfo["channelId"] = channelId.description
-            }
+            userInfo["channelId"] = channelId
             NotificationCenter.default.post(name: .payRequestTapAction, object: nil, userInfo: userInfo)
         } 
     }

--- a/Sources/StreamChatUI/xibs/cells/TableViewCellWallePayBubbleIncoming.swift
+++ b/Sources/StreamChatUI/xibs/cells/TableViewCellWallePayBubbleIncoming.swift
@@ -17,6 +17,7 @@ public class TableViewCellWallePayBubbleIncoming: UITableViewCell {
     @IBOutlet private weak var viewContainer: UIView!
     @IBOutlet private weak var subContainer: UIView!
     @IBOutlet private weak var sentThumbImageView: UIImageView!
+    @IBOutlet private weak var payRequestImageView: UIImageView!
     @IBOutlet private weak var timestampLabel: UILabel!
     @IBOutlet private weak var descriptionLabel: UILabel!
     @IBOutlet private weak var pickUpButton: UIButton!
@@ -38,7 +39,7 @@ public class TableViewCellWallePayBubbleIncoming: UITableViewCell {
     var content: ChatMessage?
     public lazy var dateFormatter: DateFormatter = .makeDefault()
     var isSender = false
-    var channel: ChatChannel?
+    var channelId: ChannelId?
     var chatClient: ChatClient?
     var client: ChatClient?
     var walletPaymentType: WalletAttachmentPayload.PaymentType = .pay
@@ -76,6 +77,9 @@ public class TableViewCellWallePayBubbleIncoming: UITableViewCell {
         sentThumbImageView.backgroundColor = Appearance.default.colorPalette.background6
         sentThumbImageView.contentMode = .scaleAspectFill
         sentThumbImageView.clipsToBounds = true
+        payRequestImageView.backgroundColor = Appearance.default.colorPalette.background6
+        payRequestImageView.contentMode = .scaleAspectFill
+        payRequestImageView.clipsToBounds = true
         // lblDetails
         lblDetails.textAlignment = .center
         lblDetails.numberOfLines = 0
@@ -101,13 +105,16 @@ public class TableViewCellWallePayBubbleIncoming: UITableViewCell {
             }
             if let themeURL = requestedThemeURL(raw: payload?.extraData), let imageUrl = URL(string: themeURL) {
                 if imageUrl.pathExtension == "gif" {
+                    sentThumbImageView.isHidden = false
                     sentThumbImageView.setGifFromURL(imageUrl)
                 } else {
-                    Nuke.loadImage(with: themeURL, into: sentThumbImageView)
+                    sentThumbImageView.isHidden = true
+                    Nuke.loadImage(with: themeURL, into: payRequestImageView)
                 }
             }
             lblDetails.text = "REQUEST: \(requestedAmount(raw: payload?.extraData) ?? "0") ONE"
         }
+        payRequestImageView.isHidden = !sentThumbImageView.isHidden
         // pickUpButton
         pickUpButton.setTitle("Pay", for: .normal)
         pickUpButton.addTarget(self, action: #selector(btnSendPacketAction), for: .touchUpInside)
@@ -282,12 +289,11 @@ public class TableViewCellWallePayBubbleIncoming: UITableViewCell {
             userInfo["recipientName"] = requestedUserName(raw: payload.extraData)
             userInfo["recipientUserId"] = requestedUserId(raw: payload.extraData)
             userInfo["requestedImageUrl"] = requestedImageUrl(raw: payload.extraData)
+            userInfo["paymentTheme"] = requestedThemeURL(raw: payload.extraData)
+            if let channelId = channelId {
+                userInfo["channelId"] = channelId.description
+            }
             NotificationCenter.default.post(name: .payRequestTapAction, object: nil, userInfo: userInfo)
-        } else {
-            guard let channelId = channel?.cid else { return }
-            var userInfo = [String: Any]()
-            userInfo["channelId"] = channelId
-            NotificationCenter.default.post(name: .sendGiftPacketTapAction, object: nil, userInfo: userInfo)
-        }
+        } 
     }
 }

--- a/Sources/StreamChatUI/xibs/cells/TableViewCellWallePayBubbleIncoming.swift
+++ b/Sources/StreamChatUI/xibs/cells/TableViewCellWallePayBubbleIncoming.swift
@@ -291,6 +291,6 @@ public class TableViewCellWallePayBubbleIncoming: UITableViewCell {
             userInfo["paymentTheme"] = requestedThemeURL(raw: payload.extraData)
             userInfo["channelId"] = channelId
             NotificationCenter.default.post(name: .payRequestTapAction, object: nil, userInfo: userInfo)
-        } 
+        }
     }
 }

--- a/Sources/StreamChatUI/xibs/cells/TableViewCellWallePayBubbleIncoming.xib
+++ b/Sources/StreamChatUI/xibs/cells/TableViewCellWallePayBubbleIncoming.xib
@@ -48,6 +48,12 @@
                                             <constraint firstAttribute="height" constant="200" id="vVR-hj-BrC"/>
                                         </constraints>
                                     </imageView>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Xni-0v-fZl">
+                                        <rect key="frame" x="0.0" y="0.0" width="230" height="200"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="200" id="lMa-Ec-PNG"/>
+                                        </constraints>
+                                    </imageView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Tao-pe-wWM">
                                         <rect key="frame" x="4" y="210" width="222" height="46"/>
                                         <subviews>
@@ -77,6 +83,10 @@
                                 <color key="backgroundColor" name="ChatNavColor"/>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="6Y0-gm-M2L" secondAttribute="trailing" constant="12" id="15G-a7-r7P"/>
+                                    <constraint firstItem="Xni-0v-fZl" firstAttribute="bottom" secondItem="HV7-Ab-F2Y" secondAttribute="bottom" id="5N3-Kw-hky"/>
+                                    <constraint firstItem="Xni-0v-fZl" firstAttribute="leading" secondItem="HV7-Ab-F2Y" secondAttribute="leading" id="76i-fU-mpX"/>
+                                    <constraint firstItem="Xni-0v-fZl" firstAttribute="top" secondItem="HV7-Ab-F2Y" secondAttribute="top" id="827-nh-HUC"/>
+                                    <constraint firstItem="Xni-0v-fZl" firstAttribute="trailing" secondItem="HV7-Ab-F2Y" secondAttribute="trailing" id="G5U-Jy-ZC2"/>
                                     <constraint firstItem="Tao-pe-wWM" firstAttribute="leading" secondItem="Nev-mG-D0r" secondAttribute="leading" constant="4" id="IJe-gk-M0s"/>
                                     <constraint firstItem="HV7-Ab-F2Y" firstAttribute="top" secondItem="Nev-mG-D0r" secondAttribute="top" id="Kaq-gC-Sex"/>
                                     <constraint firstAttribute="trailing" secondItem="HV7-Ab-F2Y" secondAttribute="trailing" id="SqP-V8-2ji"/>
@@ -153,6 +163,7 @@
                 <outlet property="cellWidthConstraint" destination="t26-eE-k0j" id="ShH-KJ-Yej"/>
                 <outlet property="descriptionLabel" destination="V3L-oi-vtA" id="8KC-3s-C50"/>
                 <outlet property="lblDetails" destination="XTN-Rw-XdJ" id="t4x-IP-SQJ"/>
+                <outlet property="payRequestImageView" destination="Xni-0v-fZl" id="vsC-5f-iQd"/>
                 <outlet property="pickUpButton" destination="6Y0-gm-M2L" id="9iI-Xc-rex"/>
                 <outlet property="sentThumbImageView" destination="HV7-Ab-F2Y" id="HZF-73-gWP"/>
                 <outlet property="subContainer" destination="Nev-mG-D0r" id="WqD-WM-bZr"/>


### PR DESCRIPTION
### 🔗 Issue Link
https://docs.google.com/document/d/1wjuu7kaHxSsR2MGvJUQ_Mz3tjoQsbx46QKDUjdku3uU/edit

### 🎯  Fixed Bug

37 - Request payment issues
A - When a user sends ONE from the payment request bubble in chat, after successful receive, there is no visual confirmation on receiver’s screen
C - Request animated gif doesn't load on receiver’s screen chat
40 - This shouldn’t show when you’re sending crypto… it should instead be the user specified occasions (birthday, anniversary, etc.)