### PR TITLE
- Button change to “+” after tapping on Emoji button

### DIFF
--- a/Sources/StreamChatUI/Composer/ComposerVC.swift
+++ b/Sources/StreamChatUI/Composer/ComposerVC.swift
@@ -615,6 +615,10 @@ open class ComposerVC: _ViewController,
     @objc open func showEmojiMenu(_ sender: UIButton) {
         // EMOJI integration
         sender.isSelected.toggle()
+        if !composerView.toolbarBackButton.isHidden {
+            composerView.toolbarBackButton.isHidden.toggle()
+            composerView.toolbarToggleButton.isHidden.toggle()
+        }
         isMenuShowing = true
         animateMenuButton()
         if sender.isSelected {


### PR DESCRIPTION
### 🔗 Issue Link
https://docs.google.com/document/d/1wjuu7kaHxSsR2MGvJUQ_Mz3tjoQsbx46QKDUjdku3uU/edit (46 - Button “<” should change to “+” after tapping on Emoji button)

### 🎯 Goal
- Change button from “<”  to “+” after tapping on Emoji button
