### PR TITLE
Poll - Handle error code API

### DIFF
--- a/Sources/StreamChatUI/CustomView/PollBubbleView.swift
+++ b/Sources/StreamChatUI/CustomView/PollBubbleView.swift
@@ -369,7 +369,7 @@ extension PollBubbleView {
         }
         if let userInfo = PollBubble.fetchPollDataCallback?(pollID) {
             setDataFromUserInfo(userInfo)
-        } else {
+        } else if !isPreview {
             var userInfo = [String: Any]()
             userInfo["group_id"] = cid.description
             userInfo["poll_id"] = pollID


### PR DESCRIPTION
### 🔗 Issue

Create/Update poll preview currently call getPoll API, which return error code from Backend

### 🎯 Goal

To make sure create poll preview doesn't call getPoll API