### PR TITLE
Fix: App crashes when user taps on the avatar and chat list at the same time

### DIFF
--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -354,9 +354,6 @@ open class ChatChannelVC: _ViewController,
             selector: #selector(updateTextFieldLayout),
             name: .updateTextfield, object: nil
         )
-        if enableKeyboardObserver {
-            keyboardHandler.start()
-        }
     }
 
     @objc func updateTextFieldLayout() {
@@ -371,15 +368,19 @@ open class ChatChannelVC: _ViewController,
         }
     }
 
-    deinit {
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         if enableKeyboardObserver {
-            keyboardHandler.stop()
+            keyboardHandler.start()
         }
     }
 
     open override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         self.navigationController?.isToolbarHidden = true
+        if enableKeyboardObserver {
+            keyboardHandler.stop()
+        }
     }
 
     override open func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
### 🔗 Issue Links

App crashes when user taps on the avatar and chat list at the same time
Video: https://drive.google.com/file/d/1LQO1F8W5peLLmnkREnrvQSsEm3pFaOKJ/view?usp=sharing
