### PR TITLE
fix redpacket timestamp alignment issue

### DIFF
--- a/Sources/StreamChatUI/ChatMessageList/ChatMessage/RedPacketSentBubble.swift
+++ b/Sources/StreamChatUI/ChatMessageList/ChatMessage/RedPacketSentBubble.swift
@@ -135,7 +135,6 @@ class RedPacketSentBubble: UITableViewCell {
         timestampLabel = createTimestampLabel()
         timestampLabel.translatesAutoresizingMaskIntoConstraints = false
         viewContainer.addSubview(timestampLabel)
-        timestampLabel.textAlignment = isSender ? .right : .left
         NSLayoutConstraint.activate([
             timestampLabel.leadingAnchor.constraint(equalTo: viewContainer.leadingAnchor, constant: 0),
             timestampLabel.trailingAnchor.constraint(equalTo: viewContainer.trailingAnchor, constant: 0),
@@ -159,6 +158,7 @@ class RedPacketSentBubble: UITableViewCell {
         } else {
             timestampLabel?.text = nil
         }
+        timestampLabel.textAlignment = isSender ? .right : .left
         configRedPacket()
     }
 


### PR DESCRIPTION
### 🔗 Issue Links

Timestamp alignment issue for Red packet (https://docs.google.com/document/d/1RwQSx07yVlZ5BInKESGlKmjwCAeWfpxQjODx13yXA2I/edit?pli=1 (28))

### 🎯 Goal

Update text alignment in Redpacket cell