### PR TITLE
Fix user already in group should be disable in invite friend

### DIFF
--- a/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
+++ b/Sources/StreamChatUI/ChatChannel/ChatChannelVC.swift
@@ -585,6 +585,7 @@ open class ChatChannelVC: _ViewController,
             guard let self = self else {
                 return
             }
+            controller.existingUsers = memberListController?.members.shuffled() ?? []
             controller.bCallbackInviteFriend = { [weak self] users in
                 guard let weakSelf = self else { return }
                 let ids = users.map{ $0.id}


### PR DESCRIPTION
### 🔗 Issue Links
- fix user already in group should be disable in invite friend (https://docs.google.com/document/d/1RwQSx07yVlZ5BInKESGlKmjwCAeWfpxQjODx13yXA2I/edit?pli=1 - [37])


### 🎯 Goal
- Existing users will be disable in Invite user list. 