### PR TITLE
Empty Group Avatar Updated

### DIFF
--- a/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.swift
+++ b/Sources/StreamChatUI/CommonViews/AvatarView/ChatChannelAvatarView.swift
@@ -135,7 +135,7 @@ open class ChatChannelAvatarView: _View, ThemeProvider, SwiftUIRepresentable {
         
         // If there are no members other than the current user in the channel, load a placeholder
         guard !lastActiveMembers.isEmpty else {
-            loadIntoAvatarImageView(from: nil, placeholder: nil)
+            loadIntoAvatarImageView(from: channel.createdBy?.imageURL, placeholder: nil)
             return
         }
         


### PR DESCRIPTION
### 🔗 Issue Links

- 26 Should have avatar when user creates private/messaging group

https://docs.google.com/document/d/1RwQSx07yVlZ5BInKESGlKmjwCAeWfpxQjODx13yXA2I/edit?pli=1