### PR TITLE
Fix Sometimes, cannot create private chat room

### DIFF
--- a/Sources/StreamChatUI/PrivateChat/PrivateGroupOTPVC.swift
+++ b/Sources/StreamChatUI/PrivateChat/PrivateGroupOTPVC.swift
@@ -126,6 +126,8 @@ open class PrivateGroupOTPVC: UIViewController {
                 guard let self = self else { return }
                 self.pushToJoinPrivateGroup()
             }
+        } else {
+            LocationManager.shared.requestGPS()
         }
     }
 }

--- a/Sources/StreamChatUI/PrivateChat/PrivateGroupOTPVC.swift
+++ b/Sources/StreamChatUI/PrivateChat/PrivateGroupOTPVC.swift
@@ -34,6 +34,7 @@ open class PrivateGroupOTPVC: UIViewController {
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         checkLocationPermission()
+        isPushed = false
     }
 
     // MARK: - IBAction


### PR DESCRIPTION
### 🔗 Issue Links
- Sometimes, cannot create private chat room https://docs.google.com/document/d/1RwQSx07yVlZ5BInKESGlKmjwCAeWfpxQjODx13yXA2I/edit?pli=1 (62)

### 🎯 Goal

User should create private group. 