### PR TITLE
Username Issue in Group Detail

### DIFF
--- a/Sources/StreamChatUI/xibs/cells/TableViewCellChatUser.swift
+++ b/Sources/StreamChatUI/xibs/cells/TableViewCellChatUser.swift
@@ -110,10 +110,11 @@ extension TableViewCellChatUser {
         if name.lowercased() == channelMember.id.lowercased()  {
             let last = channelMember.id.suffix(5)
             let first = channelMember.id.prefix(7)
+            let userName = "\(first)...\(last)".capitalizingFirstLetter()
             if channelMember.memberRole == .owner {
-                nameLabel.attributedText = getOwnerName(name: name.capitalizingFirstLetter())
+                nameLabel.attributedText = getOwnerName(name: userName)
             } else {
-                nameLabel.text = "\(first)...\(last)".capitalizingFirstLetter()
+                nameLabel.text = userName
             }
         } else {
             if channelMember.memberRole == .owner {


### PR DESCRIPTION
- 65 Should not show wallet address instead of username in group detail screen

### 🔗 Issue Links

https://docs.google.com/document/d/1RwQSx07yVlZ5BInKESGlKmjwCAeWfpxQjODx13yXA2I/edit?pli=1
